### PR TITLE
Upgrade to debian bullseye/Switch base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [3.0.0] - 2021-08-17
+### Changed
+- Upgraded to debian bullseye as base image
 
 ## [2.0.0] - 2020-10-26
 ### Changed
@@ -21,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Initial version
 
-[Unreleased]: https://github.com/particleflux/circleci-bats-kcov/compare/2.0.0...HEAD
+[Unreleased]: https://github.com/particleflux/circleci-bats-kcov/compare/3.0.0...HEAD
+[3.0.0]: https://github.com/particleflux/circleci-bats-kcov/compare/2.0.0...3.0.0
 [2.0.0]: https://github.com/particleflux/circleci-bats-kcov/compare/1.1.0...2.0.0
 [1.1.0]: https://github.com/particleflux/circleci-bats-kcov/compare/1.0.0...1.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,57 @@
-FROM kcov/kcov:38
+FROM debian:bullseye-slim AS builder
 
+ENV KCOV_VERSION 38
 ENV BATS_VERSION 1.2.1
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-    'curl=7.64*' 'git=1:2.20*' 'jq=1.5*' 'openssh-client=1:7.*' 'sudo=1.8*' \
-    && rm -rf /var/lib/apt/lists/* \
-    && useradd -ms /bin/bash circleci \
-    && echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci \
-    # install bats
-    && curl -sSL "https://github.com/bats-core/bats-core/archive/v$BATS_VERSION.tar.gz" \
+RUN apt-get update && \
+    apt-get install -y \
+        binutils-dev \
+        build-essential \
+        cmake \
+        curl \
+        git \
+        libcurl4-openssl-dev \
+        libdw-dev \
+        libiberty-dev \
+        libssl-dev \
+        ninja-build \
+        python3 \
+        zlib1g-dev \
+        ;
+
+# kcov
+RUN curl -sSL "https://github.com/SimonKagstrom/kcov/archive/refs/tags/${KCOV_VERSION}.tar.gz" \
+    | tar -C '/tmp' -xzv \
+    && cd "/tmp/kcov-${KCOV_VERSION}" \
+    && mkdir build \
+    && cd build \
+    && cmake -G 'Ninja' .. \
+    && cmake --build . \
+    && cmake --build . --target install
+
+# bats
+RUN curl -sSL "https://github.com/bats-core/bats-core/archive/v$BATS_VERSION.tar.gz" \
       | tar -C '/tmp' -xzv \
     && cd "/tmp/bats-core-$BATS_VERSION" \
     && ./install.sh /usr/local \
-    && bats --version \
-    && rm -rf "/tmp/$BATS_VERSION"
+    && bats --version
+
+
+
+
+FROM debian:bullseye-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    'curl=7.*' 'git=1:2.*' 'jq=1.*' 'openssh-client=1:8.*' 'sudo=1.*' 'ca-certificates' \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -ms /bin/bash circleci \
+    && echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci
+
+COPY --from=builder /usr/local/bin/kcov* /usr/local/bin/
+COPY --from=builder /usr/local/share/doc/kcov /usr/local/share/doc/kcov
+COPY --from=builder /usr/local/bin/bats* /usr/local/bin/
+COPY --from=builder /usr/local/libexec/bats-core /usr/local/libexec/bats-core
 
 USER circleci


### PR DESCRIPTION
Due to this image depending on `kcov/kcov`, which in turn, depends on `debian:stable-slim`, builds are failing since the nre debian `stable` _bullseye_ released on 14th.

Incorporating the kcov build into this image